### PR TITLE
Fix ss3migrate

### DIFF
--- a/code/tasks/SS3MigrateAssetsFromS3.php
+++ b/code/tasks/SS3MigrateAssetsFromS3.php
@@ -26,13 +26,28 @@ if (!class_exists('CdnImage')) {
 
 class SS3MigrateAssetsFromS3 extends BuildTask
 {
+    /**
+     * Runs task, CLI only!
+     *
+     * Args:
+     *  src (required):
+     *      Path to local copy of s3 assets.
+     *      Can be relative or absolute.
+     *      Note that PWD is framework/ so relative paths should begin with ../
+     *  ids (optional):
+     *      List of File ids to filter by.
+     *      IDs should be comma delimitered.
+     *
+     * @param [type] $request
+     * @return void
+     */
     public function run($request)
     {
         if (!Director::is_cli()) {
             throw new RuntimeException("This can only be executed from the commandline");
         }
 
-        // path can be relative or absolute
+        // get path to s3 assets
         $sourceFolder = trim($request->getVar('src'));
         if (!$sourceFolder || !is_dir($sourceFolder)) {
             throw new RuntimeException("'src' parameter must be a readable folder");
@@ -42,10 +57,11 @@ class SS3MigrateAssetsFromS3 extends BuildTask
             $sourceFolder .= '/';
         }
 
-        // use passed in IDs for testing if desired
-        $ids = $request->getVar('ids');
-
+        // files to process
         $files = File::get();
+
+        // filter by ids if supplied
+        $ids = $request->getVar('ids');
         if (strlen($ids)) {
             $ids = explode(",", $ids);
             $files = $files->filter('ID', $ids);

--- a/code/tasks/SS3MigrateAssetsFromS3.php
+++ b/code/tasks/SS3MigrateAssetsFromS3.php
@@ -8,6 +8,22 @@
  * ---
 */
 
+// simulate CdnImage incase module has been removed
+if (!class_exists('CdnImage')) {
+    class CdnImage extends \Image
+    {
+        public function getCDNFile()
+        {
+            $id = $this->ID;
+            $res = DB::query("SELECT CDNFile FROM File WHERE ID = $id");
+            if ($res->numRecords() == 1) {
+                return $res->value();
+            }
+            return null;
+        }
+    }
+}
+
 class SS3MigrateAssetsFromS3 extends BuildTask
 {
     public function run($request)

--- a/code/tasks/SS3MigrateAssetsFromS3.php
+++ b/code/tasks/SS3MigrateAssetsFromS3.php
@@ -52,7 +52,17 @@ class SS3MigrateAssetsFromS3 extends BuildTask
                 $filename = "../{$file->Filename}";
                 if (!file_exists($filename)) {
                     echo "\tCopying $sourceFile\n";
-                    copy($sourceFile, $filename);
+                    echo "\t -> to $filename\n";
+                    // ensure dir exists
+                    $destDir = dirname($filename);
+                    if (!file_exists($destDir)) {
+                        echo "\t -> mkdir $destDir\n";
+                        mkdir($destDir, 0775, true);
+                    }
+                    // copy file
+                    $result = copy($sourceFile, $filename);
+                    $result = $result ? 'SUCCESS' : 'FAILED';
+                    echo "\t -> $result\n";
                 } else {
                     echo "\tSkipped $sourceFile as the destination already exists\n";
                 }

--- a/code/tasks/SS3MigrateAssetsFromS3.php
+++ b/code/tasks/SS3MigrateAssetsFromS3.php
@@ -16,13 +16,15 @@ class SS3MigrateAssetsFromS3 extends BuildTask
             throw new RuntimeException("This can only be executed from the commandline");
         }
 
-        // The context for the following {src} parameter will be relative to "framework", so "src=../{src}" for example
-        $sourceFolder = trim($request->getVar('src'), "/");
+        // path can be relative or absolute
+        $sourceFolder = trim($request->getVar('src'));
         if (!$sourceFolder || !is_dir($sourceFolder)) {
             throw new RuntimeException("'src' parameter must be a readable folder");
         }
-
-        $sourceFolder .= "/";
+        // ensure trailing slash
+        if (substr($sourceFolder, -1) !== '/') {
+            $sourceFolder .= '/';
+        }
 
         // use passed in IDs for testing if desired
         $ids = $request->getVar('ids');
@@ -49,6 +51,7 @@ class SS3MigrateAssetsFromS3 extends BuildTask
             $sourceFile = str_replace('Default:||', $sourceFolder, $source);
 
             if (file_exists($sourceFile) && is_readable($sourceFile)) {
+                // CWD is framework/ so go up one dir
                 $filename = "../{$file->Filename}";
                 if (!file_exists($filename)) {
                     echo "\tCopying $sourceFile\n";

--- a/code/tasks/SS4MigrateAssetsFromS3.php
+++ b/code/tasks/SS4MigrateAssetsFromS3.php
@@ -4,6 +4,7 @@
  * SS4
  * ---
  * Please see the SS3 version for further information on how to use this.
+ * TODO: Migrate improvements from SS3 task to here.
  * ---
  */
 


### PR DESCRIPTION
SS3 Asset Migration Task:
- Make destination directories when required.
- Allow absolute path for src assets dir.
- Improved logging (list any dirs that failed to write to at the end, log individual success/failure, etc).
- Improve comments.
- Improve migration task to work without CDN modules.